### PR TITLE
Block iframes

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,2 +1,2 @@
-*
+/*
   X-Frame-Options: DENY


### PR DESCRIPTION
This pull request prevents other sites iframing this one.

If you don't know what iframes are, they're a thing that allows websites to spoof other websites.

Someone could put up a website called jo-dunha**n**.com, with an iframe to jo-dunha**m**.com, and can place a link on top of the "Projects" link on the page.

For that reason, I think that this is a good idea.

This adds a `_headers` file to the repository, which Netlify reads to block iframes.